### PR TITLE
Allow to specify conda store service namespace via environment variable

### DIFF
--- a/argo_jupyter_scheduler/utils.py
+++ b/argo_jupyter_scheduler/utils.py
@@ -13,6 +13,7 @@ from urllib3.exceptions import ConnectionError
 
 CONDA_STORE_TOKEN = "CONDA_STORE_TOKEN"
 CONDA_STORE_SERVICE = "CONDA_STORE_SERVICE"
+CONDA_STORE_SERVICE_NAMESPACE = "CONDA_STORE_SERVICE_NAMESPACE"
 
 CONDA_ENV_LOCATION = "/opt/conda/envs/{conda_env_name}"
 CONDA_STORE_ENV_LOCATION = "/home/conda/{env_namespace}/envs/{conda_env_name}"
@@ -114,9 +115,10 @@ def gen_log_path(input_path: str):
 def send_request(api_v1_endpoint):
     token = os.environ[CONDA_STORE_TOKEN]
     conda_store_svc_name = os.environ[CONDA_STORE_SERVICE]
+    conda_store_svc_namespace = os.environ[CONDA_STORE_SERVICE_NAMESPACE]
 
     conda_store_svc_name, conda_store_service_port = conda_store_svc_name.split(":")
-    conda_store_endpoint = f"http://{conda_store_svc_name}.dev.svc:{conda_store_service_port}/conda-store/api/v1/"
+    conda_store_endpoint = f"http://{conda_store_svc_name}.{conda_store_svc_namespace}.svc:{conda_store_service_port}/conda-store/api/v1/"
     url = urljoin(conda_store_endpoint, api_v1_endpoint)
 
     http = urllib3.PoolManager()


### PR DESCRIPTION
## Reference Issues or PRs

This is one way to fix https://github.com/nebari-dev/argo-jupyter-scheduler/issues/6. I am not sure why namespace is not included in `CONDA_STORE_SERVICE` itself, but I guess changing that would breaking a lot of deployments.

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
