### PR TITLE
Mention if papermill is not installed in failed status

### DIFF
--- a/argo_jupyter_scheduler/executor.py
+++ b/argo_jupyter_scheduler/executor.py
@@ -625,7 +625,8 @@ def update_job_status_failure(
         logger.exception("Failed to get papermill status")
         papermill_status = None
 
-    if papermill_status == 127:
+    status_not_found = 127
+    if papermill_status == status_not_found:
         status_message = "Workflow failed (papermill not found)."
     else:
         status_message = "Workflow failed."

--- a/argo_jupyter_scheduler/executor.py
+++ b/argo_jupyter_scheduler/executor.py
@@ -23,8 +23,8 @@ from argo_jupyter_scheduler.utils import (
     gen_default_html_path,
     gen_default_output_path,
     gen_log_path,
-    gen_papermill_status_path,
     gen_papermill_command_input,
+    gen_papermill_status_path,
     gen_workflow_name,
     sanitize_label,
     setup_logger,
@@ -574,7 +574,9 @@ class ArgoExecutor(ExecutionManager):
         logger.info("cron workflow updated")
 
 
-def main_container(job, use_conda_store_env, input_path, log_path, papermill_status_path, parameters):
+def main_container(
+    job, use_conda_store_env, input_path, log_path, papermill_status_path, parameters
+):
     envs = []
     if parameters is not None:
         for key, value in parameters.items():
@@ -602,15 +604,14 @@ def main_container(job, use_conda_store_env, input_path, log_path, papermill_sta
 
 
 @script()
-def update_job_status_failure(db_url, log_path, papermill_status_path, job_id=None, job_definition_id=None):
+def update_job_status_failure(
+    db_url, log_path, papermill_status_path, job_id=None, job_definition_id=None
+):
     from jupyter_scheduler.models import Status
     from jupyter_scheduler.orm import Job, create_session
     from sqlalchemy import desc
 
-    from argo_jupyter_scheduler.utils import (
-        add_file_logger,
-        setup_logger,
-    )
+    from argo_jupyter_scheduler.utils import add_file_logger, setup_logger
 
     # Sets up logging
     logger = setup_logger("update_job_status_failure")

--- a/argo_jupyter_scheduler/executor.py
+++ b/argo_jupyter_scheduler/executor.py
@@ -607,6 +607,11 @@ def update_job_status_failure(db_url, log_path, papermill_status_path, job_id=No
     from jupyter_scheduler.orm import Job, create_session
     from sqlalchemy import desc
 
+    from argo_jupyter_scheduler.utils import (
+        add_file_logger,
+        setup_logger,
+    )
+
     # Sets up logging
     logger = setup_logger("update_job_status_failure")
     add_file_logger(logger, log_path)

--- a/argo_jupyter_scheduler/utils.py
+++ b/argo_jupyter_scheduler/utils.py
@@ -211,14 +211,19 @@ def gen_papermill_command_input(
     logger.info(f"html_path: {html_path}")
     logger.info(f"papermill_status_path: {papermill_status_path}")
 
+    # Within a single-quoted string, wraps the string in single quotes
+    def sq(s):
+        return rf"'\''{s}'\''"
+
+    # These commands are executed within a single-quoted string below
     papermill = (
-        f"( papermill -k {kernel_name} {input_path} {output_path} ; "
-        f"ec=$? ; echo $ec > {papermill_status_path} ; exit $ec )"
+        f"( papermill -k {sq(kernel_name)} {sq(input_path)} {sq(output_path)} ; "
+        f"ec=$? ; echo $ec > {sq(papermill_status_path)} ; exit $ec )"
     )
-    jupyter = f"jupyter nbconvert --to html {output_path} --output {html_path}"
+    jupyter = f"jupyter nbconvert --to html {sq(output_path)} --output {sq(html_path)}"
 
     # It's important that inner quotes are single quotes to prevent shell expansion
-    return f"conda run -p {conda_env_path} /bin/sh -c '{{ {papermill} && {jupyter} ; }} >> {log_path} 2>&1'"
+    return f"conda run -p '{conda_env_path}' /bin/sh -c '{{ {papermill} && {jupyter} ; }} >> {sq(log_path)} 2>&1'"
 
 
 def sanitize_label(s: str):

--- a/argo_jupyter_scheduler/utils.py
+++ b/argo_jupyter_scheduler/utils.py
@@ -211,10 +211,11 @@ def gen_papermill_command_input(
     logger.info(f"html_path: {html_path}")
     logger.info(f"papermill_status_path: {papermill_status_path}")
 
-    papermill = f"( papermill -k {kernel_name} {input_path} {output_path} ; ec=$(echo $?) ; echo $ec > {papermill_status_path} ; exit $ec )"
+    papermill = f"( papermill -k {kernel_name} {input_path} {output_path} ; ec=$? ; echo $ec > {papermill_status_path} ; exit $ec )"
     jupyter = f"jupyter nbconvert --to html {output_path} --output {html_path}"
 
-    return f'conda run -p {conda_env_path} /bin/sh -c "{{ {papermill} && {jupyter} ; }} >> {log_path} 2>&1"'
+    # It's important that inner quotes are single quotes to prevent shell expansion
+    return f"conda run -p {conda_env_path} /bin/sh -c '{{ {papermill} && {jupyter} ; }} >> {log_path} 2>&1'"
 
 
 def sanitize_label(s: str):

--- a/argo_jupyter_scheduler/utils.py
+++ b/argo_jupyter_scheduler/utils.py
@@ -211,7 +211,10 @@ def gen_papermill_command_input(
     logger.info(f"html_path: {html_path}")
     logger.info(f"papermill_status_path: {papermill_status_path}")
 
-    papermill = f"( papermill -k {kernel_name} {input_path} {output_path} ; ec=$? ; echo $ec > {papermill_status_path} ; exit $ec )"
+    papermill = (
+        f"( papermill -k {kernel_name} {input_path} {output_path} ; "
+        f"ec=$? ; echo $ec > {papermill_status_path} ; exit $ec )"
+    )
     jupyter = f"jupyter nbconvert --to html {output_path} --output {html_path}"
 
     # It's important that inner quotes are single quotes to prevent shell expansion

--- a/argo_jupyter_scheduler/utils.py
+++ b/argo_jupyter_scheduler/utils.py
@@ -112,6 +112,11 @@ def gen_log_path(input_path: str):
     return str(p.parent / "logs.txt")
 
 
+def gen_papermill_status_path(input_path: str):
+    p = Path(input_path)
+    return str(p.parent / "papermill_status.txt")
+
+
 def send_request(api_v1_endpoint):
     token = os.environ[CONDA_STORE_TOKEN]
     conda_store_svc_name = os.environ[CONDA_STORE_SERVICE]
@@ -192,6 +197,7 @@ def gen_papermill_command_input(
     output_path: str,
     html_path: str,
     log_path: str,
+    papermill_status_path: str,
     use_conda_store_env: bool = True,
 ):
     # TODO: allow overrides
@@ -203,8 +209,9 @@ def gen_papermill_command_input(
     logger.info(f"output_path: {output_path}")
     logger.info(f"log_path: {log_path}")
     logger.info(f"html_path: {html_path}")
+    logger.info(f"papermill_status_path: {papermill_status_path}")
 
-    papermill = f"papermill -k {kernel_name} {input_path} {output_path}"
+    papermill = f"( papermill -k {kernel_name} {input_path} {output_path} ; ec=$(echo $?) ; echo $ec > {papermill_status_path} ; exit $ec )"
     jupyter = f"jupyter nbconvert --to html {output_path} --output {html_path}"
 
     return f'conda run -p {conda_env_path} /bin/sh -c "{{ {papermill} && {jupyter} ; }} >> {log_path} 2>&1"'


### PR DESCRIPTION
## Reference Issues or PRs

Fixes #8.

This PR adds additional info to the failed status message if papermill is not installed. This is implemented by capturing the status code of the papermill command and writing it to a file that's accessible by all argo steps of this job, via a shared filesystem in the staging area.

<img width="478" alt="Screenshot 2024-05-18 at 23 32 42" src="https://github.com/nebari-dev/argo-jupyter-scheduler/assets/10469885/3993b625-077e-404b-99ee-b6416450763a">


<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Testing checklist:

- [x] "Run" works, including Send to Slack, `papermill_status.txt` = 0
- [x] "Run" with an exception in the notebook is reported as "Workflow failed.", `papermill_status.txt` = 1
- [x] "Run" without papermill installed is reported as "Workflow failed (papermill not found).", `papermill_status.txt` = 127
- [x] same as 1, but with "Run on schedule"
- [x] same as 2, but with "Run on schedule"
- [x] same as 3, but with "Run on schedule".

Tested on Azure, Nebari 2024.5.1.

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [x] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [x] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [x] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [x] This content adheres to the Nebari style guides.

#### Non-text content

- [x] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [x] If there are emojis, there are not more than three in a row.
- [x] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [x] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
