### PR TITLE
feat: support ARGO_VERIFY_SSL environment variable and add tests (fixes #13)

### DIFF
--- a/argo_jupyter_scheduler/executor.py
+++ b/argo_jupyter_scheduler/executor.py
@@ -1,7 +1,6 @@
 import os
 from typing import Dict, Union
 
-from hera.shared import global_config
 from hera.workflows import Container, CronWorkflow, Env, Step, Steps, Workflow, script
 from hera.workflows.models import ContinueOn, TTLStrategy, WorkflowStopRequest
 from hera.workflows.service import WorkflowsService
@@ -18,7 +17,6 @@ from jupyter_scheduler.utils import get_utc_timestamp
 
 from argo_jupyter_scheduler.utils import (
     WorkflowActionsEnum,
-    _env_bool,
     add_file_logger,
     authenticate,
     gen_cron_workflow_name,
@@ -195,7 +193,7 @@ class ArgoExecutor(ExecutionManager):
         # Configure logging to file first
         add_file_logger(logger, log_path)
 
-        authenticate(verify_ssl=_env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl))
+        authenticate()
 
         logger.info("creating workflow...")
         logger.info(f"create time: {job.create_time}")
@@ -291,9 +289,7 @@ class ArgoExecutor(ExecutionManager):
         logger.info("workflow created")
 
     def delete_workflow(self, job_id: str):
-        global_cfg = authenticate(
-            verify_ssl=_env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl)
-        )
+        global_cfg = authenticate()
 
         logger.info("deleting workflow...")
 
@@ -313,9 +309,7 @@ class ArgoExecutor(ExecutionManager):
         logger.info("workflow deleted")
 
     def stop_workflow(self, job_id):
-        global_cfg = authenticate(
-            verify_ssl=_env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl)
-        )
+        global_cfg = authenticate()
 
         logger.info("stopping workflow...")
 
@@ -490,7 +484,7 @@ class ArgoExecutor(ExecutionManager):
         db_url: str,
         use_conda_store_env: bool = True,
     ):
-        authenticate(verify_ssl=_env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl))
+        authenticate()
 
         logger.info("creating cron workflow...")
 
@@ -510,9 +504,7 @@ class ArgoExecutor(ExecutionManager):
         logger.info("cron workflow created")
 
     def delete_cron_workflow(self, job_definition_id: str):
-        global_cfg = authenticate(
-            verify_ssl=_env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl)
-        )
+        global_cfg = authenticate()
 
         logger.info("deleting cron workflow...")
 
@@ -542,7 +534,7 @@ class ArgoExecutor(ExecutionManager):
         db_url: str,
         use_conda_store_env: bool = True,
     ):
-        authenticate(verify_ssl=_env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl))
+        authenticate()
 
         logger.info("updating cron workflow...")
 

--- a/argo_jupyter_scheduler/executor.py
+++ b/argo_jupyter_scheduler/executor.py
@@ -1,6 +1,7 @@
 import os
 from typing import Dict, Union
 
+from hera.shared import global_config
 from hera.workflows import Container, CronWorkflow, Env, Step, Steps, Workflow, script
 from hera.workflows.models import ContinueOn, TTLStrategy, WorkflowStopRequest
 from hera.workflows.service import WorkflowsService
@@ -17,6 +18,7 @@ from jupyter_scheduler.utils import get_utc_timestamp
 
 from argo_jupyter_scheduler.utils import (
     WorkflowActionsEnum,
+    _env_bool,
     add_file_logger,
     authenticate,
     gen_cron_workflow_name,
@@ -193,7 +195,7 @@ class ArgoExecutor(ExecutionManager):
         # Configure logging to file first
         add_file_logger(logger, log_path)
 
-        authenticate()
+        authenticate(verify_ssl=_env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl))
 
         logger.info("creating workflow...")
         logger.info(f"create time: {job.create_time}")
@@ -289,7 +291,9 @@ class ArgoExecutor(ExecutionManager):
         logger.info("workflow created")
 
     def delete_workflow(self, job_id: str):
-        global_config = authenticate()
+        global_cfg = authenticate(
+            verify_ssl=_env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl)
+        )
 
         logger.info("deleting workflow...")
 
@@ -297,7 +301,7 @@ class ArgoExecutor(ExecutionManager):
             wfs = WorkflowsService()
             wfs.delete_workflow(
                 name=gen_workflow_name(job_id),
-                namespace=global_config.namespace,
+                namespace=global_cfg.namespace,
             )
         except Exception as e:
             # Hera-Workflows raises generic Exception for all errors :(
@@ -309,21 +313,23 @@ class ArgoExecutor(ExecutionManager):
         logger.info("workflow deleted")
 
     def stop_workflow(self, job_id):
-        global_config = authenticate()
+        global_cfg = authenticate(
+            verify_ssl=_env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl)
+        )
 
         logger.info("stopping workflow...")
 
         try:
             req = WorkflowStopRequest(
                 name=gen_workflow_name(job_id),
-                namespace=global_config.namespace,
+                namespace=global_cfg.namespace,
             )
 
             wfs = WorkflowsService()
             wfs.stop_workflow(
                 name=gen_workflow_name(job_id),
                 req=req,
-                namespace=global_config.namespace,
+                namespace=global_cfg.namespace,
             )
         except Exception as e:
             # Hera-Workflows raises generic Exception for all errors :(
@@ -484,7 +490,7 @@ class ArgoExecutor(ExecutionManager):
         db_url: str,
         use_conda_store_env: bool = True,
     ):
-        authenticate()
+        authenticate(verify_ssl=_env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl))
 
         logger.info("creating cron workflow...")
 
@@ -504,7 +510,9 @@ class ArgoExecutor(ExecutionManager):
         logger.info("cron workflow created")
 
     def delete_cron_workflow(self, job_definition_id: str):
-        global_config = authenticate()
+        global_cfg = authenticate(
+            verify_ssl=_env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl)
+        )
 
         logger.info("deleting cron workflow...")
 
@@ -512,7 +520,7 @@ class ArgoExecutor(ExecutionManager):
             wfs = WorkflowsService()
             wfs.delete_cron_workflow(
                 name=gen_cron_workflow_name(job_definition_id),
-                namespace=global_config.namespace,
+                namespace=global_cfg.namespace,
             )
         except Exception as e:
             # Hera-Workflows raises generic Exception for all errors :(
@@ -534,7 +542,7 @@ class ArgoExecutor(ExecutionManager):
         db_url: str,
         use_conda_store_env: bool = True,
     ):
-        authenticate()
+        authenticate(verify_ssl=_env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl))
 
         logger.info("updating cron workflow...")
 

--- a/argo_jupyter_scheduler/utils.py
+++ b/argo_jupyter_scheduler/utils.py
@@ -50,6 +50,26 @@ def add_file_logger(logger, log_path):
 logger = setup_logger(__name__)
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    """Parse boolean environment variables in a forgiving way.
+
+    Accepts: true/false, 1/0, yes/no, y/n, on/off (case-insensitive).
+    If the variable is unset, returns default.
+    """
+    raw = os.getenv(name)
+    if not raw:
+        return default
+
+    v = raw.strip().lower()
+    if v in {"1", "true", "t", "yes", "y", "on"}:
+        return True
+    if v in {"0", "false", "f", "no", "n", "off"}:
+        return False
+
+    msg = f"Invalid value for {name}={raw!r}. Expected a boolean (true/false, 1/0, yes/no, on/off)."
+    raise ValueError(msg)
+
+
 def authenticate():
     namespace = os.environ["ARGO_NAMESPACE"]
     if not namespace:
@@ -66,9 +86,13 @@ def authenticate():
     server = f"https://{os.environ['ARGO_SERVER']}"
     host = urljoin(server, base_href)
 
+    # Allow opting out of SSL verification (default stays True)
+    verify_ssl = _env_bool("ARGO_VERIFY_SSL", True)
+
     global_config.host = host
     global_config.token = token
     global_config.namespace = namespace
+    global_config.verify_ssl = verify_ssl
 
     return global_config
 

--- a/argo_jupyter_scheduler/utils.py
+++ b/argo_jupyter_scheduler/utils.py
@@ -57,7 +57,7 @@ def _env_bool(name: str, default: bool) -> bool:
     If the variable is unset, returns default.
     """
     raw = os.getenv(name)
-    if not raw:
+    if raw is None:
         return default
 
     v = raw.strip().lower()
@@ -66,11 +66,14 @@ def _env_bool(name: str, default: bool) -> bool:
     if v in {"0", "false", "f", "no", "n", "off"}:
         return False
 
-    msg = f"Invalid value for {name}={raw!r}. Expected a boolean (true/false, 1/0, yes/no, on/off)."
+    msg = (
+        f"Invalid value for {name}={raw!r}. "
+        "Expected a boolean (true/false, 1/0, yes/no, on/off)."
+    )
     raise ValueError(msg)
 
 
-def authenticate():
+def authenticate(verify_ssl: bool | None = None):
     namespace = os.environ["ARGO_NAMESPACE"]
     if not namespace:
         namespace = "dev"
@@ -86,8 +89,8 @@ def authenticate():
     server = f"https://{os.environ['ARGO_SERVER']}"
     host = urljoin(server, base_href)
 
-    # Allow opting out of SSL verification (default stays True)
-    verify_ssl = _env_bool("ARGO_VERIFY_SSL", True)
+    if verify_ssl is None:
+        verify_ssl = _env_bool("ARGO_VERIFY_SSL", global_config.verify_ssl)
 
     global_config.host = host
     global_config.token = token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
   "pre-commit",
   "pytest-cov",
   "pytest",
-  "pytest",
+  "pytest-jupyter",
   "ruff",
 ]
 

--- a/tests/test_utils_verify_ssl.py
+++ b/tests/test_utils_verify_ssl.py
@@ -1,0 +1,63 @@
+import pytest
+
+from hera.shared import global_config
+
+from argo_jupyter_scheduler.utils import authenticate
+
+
+def _set_required_env(monkeypatch):
+    monkeypatch.setenv("ARGO_NAMESPACE", "dev")
+    monkeypatch.setenv("ARGO_TOKEN", "Bearer abc123")
+    monkeypatch.setenv("ARGO_BASE_HREF", "/")
+    monkeypatch.setenv("ARGO_SERVER", "argo.example.com")
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_config():
+    # Snapshot/restore global_config to avoid cross-test contamination.
+    old = {
+        "host": getattr(global_config, "host", None),
+        "token": getattr(global_config, "token", None),
+        "namespace": getattr(global_config, "namespace", None),
+        "verify_ssl": getattr(global_config, "verify_ssl", None),
+    }
+    yield
+    global_config.host = old["host"]
+    global_config.token = old["token"]
+    global_config.namespace = old["namespace"]
+    if hasattr(global_config, "verify_ssl"):
+        global_config.verify_ssl = old["verify_ssl"]
+
+
+def test_authenticate_defaults_verify_ssl_true(monkeypatch):
+    _set_required_env(monkeypatch)
+    monkeypatch.delenv("ARGO_VERIFY_SSL", raising=False)
+
+    cfg = authenticate()
+    assert cfg.verify_ssl is True
+
+
+@pytest.mark.parametrize("val", ["false", "False", "0", "no", "off", " OFF "])
+def test_authenticate_verify_ssl_false(monkeypatch, val):
+    _set_required_env(monkeypatch)
+    monkeypatch.setenv("ARGO_VERIFY_SSL", val)
+
+    cfg = authenticate()
+    assert cfg.verify_ssl is False
+
+
+@pytest.mark.parametrize("val", ["true", "True", "1", "yes", "on", " ON "])
+def test_authenticate_verify_ssl_true(monkeypatch, val):
+    _set_required_env(monkeypatch)
+    monkeypatch.setenv("ARGO_VERIFY_SSL", val)
+
+    cfg = authenticate()
+    assert cfg.verify_ssl is True
+
+
+def test_authenticate_invalid_verify_ssl_raises(monkeypatch):
+    _set_required_env(monkeypatch)
+    monkeypatch.setenv("ARGO_VERIFY_SSL", "maybe")
+
+    with pytest.raises(ValueError):
+        authenticate()


### PR DESCRIPTION
## Reference Issues or PRs
Fixes #13 

## What does this implement/fix?
This PR adds support for configuring SSL verification via the `ARGO_VERIFY_SSL`
environment variable when creating the Argo `WorkflowService`.

### Behavior
- Default remains **verify=True** (no behavior change)
- Supports common boolean values (case-insensitive):
    - true/false
    - 1/0
    - yes/no
    - on/off
- Raises a `ValueError` for invalid values
- Adds unit tests to validate parsing behavior
This helps users running behind proxies or with self-signed certificates
(e.g., local or Nebari environments).

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [x] Other (please describe): Dev/test dependency update only

## Testing

- [x] Did you test the pull request locally? 
     python3 -m pytest -q
     Result: 20 passed
- [x] Did you add new tests?
       - `tests/test_utils_verify_ssl.py`
## Documentation
 No user-facing documentation changes required. Configuration is via environment variable only

### Access-centered content checklist

#### Text styling

- [x] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [x] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [x] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [x] This content adheres to the Nebari style guides.

#### Non-text content

- [x] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [x] If there are emojis, there are not more than three in a row.
- [x] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [x] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?
This implementation follows Hera’s existing `verify_ssl` behavior and keeps
the default secure configuration.
